### PR TITLE
Clear interval when dismounting component

### DIFF
--- a/client/src/components/InitialPromptCreationScreen/InitialPromptCreationScreen.jsx
+++ b/client/src/components/InitialPromptCreationScreen/InitialPromptCreationScreen.jsx
@@ -13,10 +13,6 @@ class InitialPromptCreationScreen extends React.Component {
     this.updateGameState = this.updateGameState.bind(this);
   }
 
-  componentDidMount() {
-    setInterval(this.updateGameState, 3000);
-  }
-
   async onStartGameButtonClicked() {
     const { gameState, onGameStateChanged } = this.props;
     const { groupName, currentPlayer } = gameState;

--- a/client/src/components/WaitingForPlayersScreen/WaitingForPlayersScreen.jsx
+++ b/client/src/components/WaitingForPlayersScreen/WaitingForPlayersScreen.jsx
@@ -9,13 +9,22 @@ class WaitingForPlayersScreen extends React.Component {
     super(props);
     this.state = {
       error: null,
+      timerId: null,
     };
     this.updateGameState = this.updateGameState.bind(this);
     this.onStartGameButtonClicked = this.onStartGameButtonClicked.bind(this);
   }
 
   componentDidMount() {
-    setInterval(this.updateGameState, 3000);
+    const timerId = setInterval(this.updateGameState, 3000);
+    this.setState({ timerId });
+  }
+
+  componentWillUnmount() {
+    const { timerId } = this.state;
+    if (timerId !== null) {
+      clearInterval(timerId);
+    }
   }
 
   async onStartGameButtonClicked() {


### PR DESCRIPTION
Fixes https://github.com/danbarragan/drawydraw/issues/14
- Keeps the timerId returned by setInterval
- Clears it before the component dismounts
- Removes the setInterval from the initial prompt creation screen for now since I'm not sure we'll need it there (at least not until the prompts are entered ) and it was hard to test this fix with that in there.

@mick-warehime 