### PR TITLE
add eslint precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: eslint
         name: eslint
-        entry: ./client/node_modules/.bin/eslint
+        entry: ./client/node_modules/.bin/eslint --fix
         language: node
         language_version: system
         files: \.(js|jsx)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
--   repo: https://github.com/tekwizely/pre-commit-golang
+-   repo: git://github.com/Bahjat/pre-commit-golang
     rev: master
     hooks:
-    -   id: go-fmt
+    -   id: go-fmt-import
     -   id: go-lint
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: eslint
         name: eslint
-        entry: ./client/node_modules/.bin/eslint --fix
+        entry: ./client/node_modules/.bin/eslint --
         language: node
         language_version: system
         files: \.(js|jsx)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,11 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
+-   repo: local
+    hooks:
+      - id: eslint
+        name: eslint
+        entry: ./client/node_modules/.bin/eslint
+        language: node
+        language_version: system
+        files: \.(js|jsx)$

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,7 +1,7 @@
 {
     "extends": ["airbnb", "airbnb/hooks"],
     "parserOptions": {
-        "ecmaVersion": 2020,
+        "ecmaVersion": 8,
         "sourceType": "module",
         "ecmaFeatures": {
             "jsx": true

--- a/server/main.go
+++ b/server/main.go
@@ -160,5 +160,6 @@ func setGameState(ctx *gin.Context) {
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, formatError(fmt.Sprintf("Error setting GameState: %s", err.Error())))
 		return
 	}
+
 	ctx.JSON(http.StatusOK, &gameState)
 }


### PR DESCRIPTION
it took me all night to figure this out but it finally worked! I changed the single quotes in Game.jsx to double quotes and detect the issue when trying to commit files. 

without the --fix option the pre-commit simply tells you about the problem
go-fmt...............................................(no files to check)Skipped
go-lint..............................................(no files to check)Skipped
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
eslint...................................................................Failed
- hook id: eslint
- exit code: 1

/home/miiick/Documents/projects/drawydraw/client/src/components/Game/Game.jsx
  72:30  error  Strings must use singlequote  quotes

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.


with the --fix option in the pre-commit it automagically runs the fix and updates your current git branch

go-fmt...............................................(no files to check)Skipped
go-lint..............................................(no files to check)Skipped
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
eslint...................................................................Failed
- hook id: eslint
- files were modified by this hook


then run
git add -A
git commit -m "foobar"
...
profit
