### PR TITLE
Delegate populating game status responses to each state

### DIFF
--- a/server/models/game.go
+++ b/server/models/game.go
@@ -29,32 +29,31 @@ const (
 // Player contains all the information relevant to a game's participant
 type Player struct {
 	// Todo: Probably worth having a sort of device id in case two players register with the same name
-	Name           string  `json:"name"`
-	Host           bool    `json:"host"`
-	Points         uint64  `json:"points"`
-	AssignedPrompt *Prompt `json:"-"`
+	Name           string
+	Host           bool
+	Points         uint64
+	AssignedPrompt *Prompt
 }
 
 type Prompt struct {
 	Author     string
-	Group      string
 	Noun       string
 	Adjectives []string
 }
 
 type Drawing struct {
-	ImageData string `json:"imageData"`
-	Author    string `json:"author"`
+	ImageData string
+	Author    string
 }
 
 // Game contains all data that represents the game at any point
 type Game struct {
-	GroupName    string     `json:"groupName"`
-	Players      []*Player  `json:"players"`
-	CurrentState GameState  `json:"currentState"`
-	HostPlayer   string     `json:"hostPlayer"`
-	Prompts      []*Prompt  `json:"prompts"`
-	Drawings     []*Drawing `json:"drawings"`
+	GroupName    string
+	Players      []*Player
+	CurrentState GameState
+	HostPlayer   string
+	Prompts      []*Prompt
+	Drawings     []*Drawing
 }
 
 // Todo: Put SaveGame/LoadGame methods behind an interface to faciliate unit tests

--- a/server/utils/statemanager/drawings_in_progress_state.go
+++ b/server/utils/statemanager/drawings_in_progress_state.go
@@ -32,3 +32,11 @@ func (state drawingsInProgressState) submitDrawing(playerName string, encodedIma
 func (state drawingsInProgressState) addPrompt(prompts *models.Prompt) error {
 	return errors.New("addprompts not supported for drawing state")
 }
+
+func (state drawingsInProgressState) addGameStatusPropertiesForPlayer(player *models.Player, gameStatus *GameStatusResponse) error {
+	gameStatus.CurrentPlayer.AssignedPrompt = &AssignedPrompt{
+		Adjectives: player.AssignedPrompt.Adjectives,
+		Noun:       player.AssignedPrompt.Noun,
+	}
+	return nil
+}

--- a/server/utils/statemanager/prompt_creating_state.go
+++ b/server/utils/statemanager/prompt_creating_state.go
@@ -44,3 +44,7 @@ func assignPrompts(game *models.Game) {
 		player.AssignedPrompt = playerPromptMap[assignedPromptAuthor]
 	}
 }
+
+func (state promptCreatingState) addGameStatusPropertiesForPlayer(player *models.Player, gameStatus *GameStatusResponse) error {
+	return nil
+}

--- a/server/utils/statemanager/state.go
+++ b/server/utils/statemanager/state.go
@@ -10,4 +10,5 @@ type state interface {
 	addPrompt(prompt *models.Prompt) error
 	startGame(groupName string, playerName string) error
 	submitDrawing(playerName string, encodedImage string) error
+	addGameStatusPropertiesForPlayer(player *models.Player, gameStatus *GameStatusResponse) error
 }

--- a/server/utils/statemanager/voting_state.go
+++ b/server/utils/statemanager/voting_state.go
@@ -25,3 +25,7 @@ func (state voting) submitDrawing(playerName string, encodedImage string) error 
 func (state voting) addPrompt(prompts *models.Prompt) error {
 	return errors.New("addprompts not supported for voting state")
 }
+
+func (state voting) addGameStatusPropertiesForPlayer(player *models.Player, gameStatus *GameStatusResponse) error {
+	return nil
+}

--- a/server/utils/statemanager/waiting_for_players_state.go
+++ b/server/utils/statemanager/waiting_for_players_state.go
@@ -29,3 +29,7 @@ func (state waitingForPlayersState) submitDrawing(playerName string, encodedImag
 func (state waitingForPlayersState) addPrompt(prompts *models.Prompt) error {
 	return errors.New("addPrompt not supported for waiting for players state")
 }
+
+func (state waitingForPlayersState) addGameStatusPropertiesForPlayer(player *models.Player, gameStatus *GameStatusResponse) error {
+	return nil
+}


### PR DESCRIPTION
Changes the way `formatGameStateForPlayer` works:
- Now `gameStatusForPlayer` only fills in base properties (e.g. player data, group and current status)
- It will also call `addGameStatusPropertiesForPlayer` on the current state which will then handle adding state-dependent properties (e.g. assigned prompts in the drawing stage)
- It now returns its own models instead of the models used for storage

@mick-warehime 

Addresses point 2 of https://github.com/danbarragan/drawydraw/issues/37