### PR TITLE
Finish drawing state

### DIFF
--- a/client/src/components/DrawingScreen/DrawingScreen.jsx
+++ b/client/src/components/DrawingScreen/DrawingScreen.jsx
@@ -172,7 +172,7 @@ class DrawingScreen extends React.Component {
             players.filter((player) => player.name !== currentPlayer.name).map((player) => (
               <li key={player.name}>
                 {player.name}
-                {player.hasPendingAction ? ' is still drawing' : ' is done'}
+                {player.hasPendingActions ? ' is still drawing' : ' is done'}
               </li>
             ))
           }
@@ -192,7 +192,7 @@ DrawingScreen.propTypes = {
   gameState: PropTypes.shape({
     players: PropTypes.arrayOf(PropTypes.shape({
       name: PropTypes.string.isRequired,
-      hasPendingAction: PropTypes.bool.isRequired,
+      hasPendingActions: PropTypes.bool.isRequired,
     })),
     currentPlayer: PropTypes.shape({
       name: PropTypes.string.isRequired,

--- a/client/src/components/DrawingScreen/DrawingScreen.jsx
+++ b/client/src/components/DrawingScreen/DrawingScreen.jsx
@@ -116,7 +116,7 @@ class DrawingScreen extends React.Component {
     }
   }
 
-  async updateGameState() {
+  updateGameState() {
     const { gameState, onGameStateChanged } = this.props;
     const { groupName, currentPlayer } = gameState;
     const { name: playerName } = currentPlayer;

--- a/client/src/components/DrawingScreen/DrawingScreen.jsx
+++ b/client/src/components/DrawingScreen/DrawingScreen.jsx
@@ -132,9 +132,11 @@ class DrawingScreen extends React.Component {
   render() {
     const { error, currentBrushColor, currentBrushSize } = this.state;
     const { gameState } = this.props;
-    const { noun, adjectives } = gameState.currentPlayer.assignedPrompt;
-    return (
-      <div className="screen">
+    const {currentPlayer} = gameState;
+    const { noun, adjectives } = currentPlayer.assignedPrompt;
+    const { players } = gameState;
+    const drawingElements = (
+      <div>
         <h1>
           Draw
           {' '}
@@ -160,6 +162,26 @@ class DrawingScreen extends React.Component {
         />
         <button type="button" className="button buttonTypeA" onClick={this.onSubmitClick}>Submit</button>
         <button type="button" className="button buttonTypeB" onClick={this.onClearClick}>Clear</button>
+      </div>
+    );
+    const waitingElements = (
+      <div>
+        <h3>Thank you for your drawing, waiting for other players...</h3>
+        <ul>
+          {
+            players.filter((player) => player.name !== currentPlayer.name).map((player) => (
+              <li key={player.name}>
+                {player.name}
+                {player.hasPendingAction ? ' is still drawing' : ' is done'}
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+    );
+    return (
+      <div className="screen">
+        {currentPlayer.hasCompletedAction ? waitingElements : drawingElements}
         <h3 className="error">{error}</h3>
       </div>
     );
@@ -168,12 +190,17 @@ class DrawingScreen extends React.Component {
 
 DrawingScreen.propTypes = {
   gameState: PropTypes.shape({
+    players: PropTypes.arrayOf(PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      hasPendingAction: PropTypes.bool.isRequired,
+    })),
     currentPlayer: PropTypes.shape({
       name: PropTypes.string.isRequired,
       assignedPrompt: PropTypes.shape({
         adjectives: PropTypes.arrayOf(PropTypes.string).isRequired,
         noun: PropTypes.string,
       }),
+      hasCompletedAction: PropTypes.bool.isRequired,
     }).isRequired,
     groupName: PropTypes.string.isRequired,
   }).isRequired,

--- a/client/src/components/DrawingScreen/DrawingScreen.test.jsx
+++ b/client/src/components/DrawingScreen/DrawingScreen.test.jsx
@@ -6,7 +6,7 @@ import '../../test/setupTests';
 
 describe('DrawingScreen', () => {
   const mockGameState = {
-    players: [{ name: 'baby cat', hasPendingActions: true }, { name: 'omega cat', hasPendingActions: true }],
+    players: [{ name: 'baby cat', hasPendingAction: true }, { name: 'omega cat', hasPendingAction: true }],
     groupName: 'kitties4Life',
     currentPlayer: {
       name: 'baby cat',

--- a/client/src/components/DrawingScreen/DrawingScreen.test.jsx
+++ b/client/src/components/DrawingScreen/DrawingScreen.test.jsx
@@ -6,10 +6,12 @@ import '../../test/setupTests';
 
 describe('DrawingScreen', () => {
   const mockGameState = {
+    players: [{ name: 'baby cat', hasPendingAction: true }, { name: 'omega cat', hasPendingAction: true }],
     groupName: 'kitties4Life',
     currentPlayer: {
       name: 'baby cat',
       assignedPrompt: { noun: 'porridge', adjectives: ['interstellar', 'majestic'] },
+      hasCompletedAction: false,
     },
   };
   const mockOnGameStateChanged = jest.fn();

--- a/client/src/components/DrawingScreen/DrawingScreen.test.jsx
+++ b/client/src/components/DrawingScreen/DrawingScreen.test.jsx
@@ -6,7 +6,7 @@ import '../../test/setupTests';
 
 describe('DrawingScreen', () => {
   const mockGameState = {
-    players: [{ name: 'baby cat', hasPendingAction: true }, { name: 'omega cat', hasPendingAction: true }],
+    players: [{ name: 'baby cat', hasPendingActions: true }, { name: 'omega cat', hasPendingActions: true }],
     groupName: 'kitties4Life',
     currentPlayer: {
       name: 'baby cat',

--- a/client/src/components/VotingScreen/VotingScreen.jsx
+++ b/client/src/components/VotingScreen/VotingScreen.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import { formatServerError } from '../../utils/errorFormatting';
 import './VotingScreen.css';
+import UpdateGameState from '../../utils/updateGameState';
 
 class VotingScreen extends React.Component {
   constructor(props) {
@@ -17,17 +18,16 @@ class VotingScreen extends React.Component {
     this.castVote = this.castVote.bind(this);
   }
 
-  // Todo: Probably move to a helper since it's going to be used in other screens
-  async updateGameState() {
+  updateGameState() {
     const { gameState, onGameStateChanged } = this.props;
     const { groupName, currentPlayer } = gameState;
     const { name: playerName } = currentPlayer;
-    try {
-      const response = await axios.get(`/api/get-game-status/${groupName}?playerName=${playerName}`);
-      onGameStateChanged(response.data);
-    } catch (error) {
-      this.setState({ error: formatServerError(error) });
-    }
+    UpdateGameState(
+      groupName,
+      playerName,
+      onGameStateChanged,
+      (error) => { this.setState({ error: formatServerError(error) }); },
+    );
   }
 
   handleOptionChange(voteEvent) {

--- a/client/src/components/VotingScreen/VotingScreen.jsx
+++ b/client/src/components/VotingScreen/VotingScreen.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import axios from 'axios';
 import PropTypes from 'prop-types';
 import { formatServerError } from '../../utils/errorFormatting';
 import './VotingScreen.css';

--- a/client/src/components/WaitingForPlayersScreen/WaitingForPlayersScreen.jsx
+++ b/client/src/components/WaitingForPlayersScreen/WaitingForPlayersScreen.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 import { formatServerError } from '../../utils/errorFormatting';
-
+import UpdateGameState from '../../utils/updateGameState';
 
 class WaitingForPlayersScreen extends React.Component {
   constructor(props) {
@@ -40,17 +40,16 @@ class WaitingForPlayersScreen extends React.Component {
     }
   }
 
-  // Todo: Probably move to a helper since it's going to be used in other screens
   async updateGameState() {
     const { gameState, onGameStateChanged } = this.props;
     const { groupName, currentPlayer } = gameState;
     const { name: playerName } = currentPlayer;
-    try {
-      const response = await axios.get(`/api/get-game-status/${groupName}?playerName=${playerName}`);
-      onGameStateChanged(response.data);
-    } catch (error) {
-      this.setState({ error: formatServerError(error) });
-    }
+    UpdateGameState(
+      groupName,
+      playerName,
+      onGameStateChanged,
+      (error) => { this.setState({ error: formatServerError(error) }); },
+    );
   }
 
   render() {

--- a/client/src/components/WaitingForPlayersScreen/WaitingForPlayersScreen.jsx
+++ b/client/src/components/WaitingForPlayersScreen/WaitingForPlayersScreen.jsx
@@ -40,7 +40,7 @@ class WaitingForPlayersScreen extends React.Component {
     }
   }
 
-  async updateGameState() {
+  updateGameState() {
     const { gameState, onGameStateChanged } = this.props;
     const { groupName, currentPlayer } = gameState;
     const { name: playerName } = currentPlayer;

--- a/client/src/utils/updateGameState.js
+++ b/client/src/utils/updateGameState.js
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+async function UpdateGameState(groupName, playerName, onSuccess, onError) {
+  try {
+    const response = await axios.get(`/api/get-game-status/${groupName}?playerName=${playerName}`);
+    onSuccess(response.data);
+  } catch (error) {
+    onError(error);
+  }
+}
+
+export default UpdateGameState;

--- a/server/main.go
+++ b/server/main.go
@@ -30,6 +30,7 @@ func setupRouter(port string) *gin.Engine {
 	router.POST("/api/set-game-state", setGameState)
 	router.POST("/api/echo", echoTest)
 	router.POST("/api/add-prompt", addPrompt)
+	router.POST("/api/submit-drawing", submitDrawing)
 
 	return router
 }
@@ -90,6 +91,27 @@ func addPrompt(ctx *gin.Context) {
 	gameState, err := statemanager.AddPrompt(addPromptRequest.PlayerName, addPromptRequest.GroupName, addPromptRequest.Noun, addPromptRequest.Adjective1, addPromptRequest.Adjective2)
 	if err != nil {
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, formatError(fmt.Sprintf("Error adding prompt: %s", err.Error())))
+		return
+	}
+	ctx.JSON(http.StatusOK, &gameState)
+}
+
+type submitDrawingRequest struct {
+	PlayerName string `json:"playerName"`
+	GroupName  string `json:"groupName"`
+	ImageData  string `json:"imageData"`
+}
+
+func submitDrawing(ctx *gin.Context) {
+	request := submitDrawingRequest{}
+	err := ctx.BindJSON(&request)
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, formatError(fmt.Sprintf("Invalid request: %s", err.Error())))
+		return
+	}
+	gameState, err := statemanager.SubmitDrawing(request.PlayerName, request.GroupName, request.ImageData)
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, formatError(fmt.Sprintf("Error submitting drawing: %s", err.Error())))
 		return
 	}
 	ctx.JSON(http.StatusOK, &gameState)

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -234,8 +234,7 @@ func TestSubmitDrawingRoute(t *testing.T) {
 	}
 	req = createRequest(t, "POST", "/api/start-game", data)
 	sendRequest(t, req, http.StatusOK)
-
-	//Make a post to the add prompts route from player 1, confirm state stays at "Initial Prompt Creation"
+	// Add prompts for both players
 	data = map[string]string{
 		"groupName":  "submitDrawingRoute",
 		"playerName": "player1",

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -270,8 +270,8 @@ func TestSubmitDrawingRoute(t *testing.T) {
 		},
 		CurrentState: string(models.DrawingsInProgress),
 		Players: []*statemanager.Player{
-			{Name: "player1", Host: true, HasPendingActions: false},
-			{Name: "player2", HasPendingActions: true},
+			{Name: "player1", Host: true, HasPendingAction: false},
+			{Name: "player2", HasPendingAction: true},
 		},
 	}
 	assert.EqualValues(t, expectedGameState, actualGameState)

--- a/server/utils/statemanager/drawings_in_progress_state.go
+++ b/server/utils/statemanager/drawings_in_progress_state.go
@@ -51,7 +51,7 @@ func (state drawingsInProgressState) addGameStatusPropertiesForPlayer(player *mo
 	// Mark players who haven't submitted their drawing as having pending actions
 	for _, p := range gameStatus.Players {
 		_, hasDrawing := authorToDrawingMap[p.Name]
-		p.HasPendingActions = !hasDrawing
+		p.HasPendingAction = !hasDrawing
 		if p.Name == player.Name {
 			gameStatus.CurrentPlayer.HasCompletedAction = hasDrawing
 		}

--- a/server/utils/statemanager/state_manager.go
+++ b/server/utils/statemanager/state_manager.go
@@ -20,10 +20,10 @@ type AssignedPrompt struct {
 }
 
 type Player struct {
-	Name              string `json:"name"`
-	Host              bool   `json:"host"`
-	Points            uint64 `json:"points"`
-	HasPendingActions bool   `json:"hasPendingAction"`
+	Name             string `json:"name"`
+	Host             bool   `json:"host"`
+	Points           uint64 `json:"points"`
+	HasPendingAction bool   `json:"hasPendingAction"`
 }
 
 type CurrentPlayer struct {

--- a/server/utils/statemanager/state_manager_test.go
+++ b/server/utils/statemanager/state_manager_test.go
@@ -143,3 +143,31 @@ func TestGameStatusForPlayer_Fails_PlayerMissing(t *testing.T) {
 	assert.Nil(t, gameStatus)
 	assert.NotNil(t, err)
 }
+
+func TestSubmitDrawing(t *testing.T) {
+	//set up a group, add players, add a prompt
+	groupName := randomGroupName()
+	CreateGroup(groupName)
+	AddPlayer("host cat", groupName, true)
+	AddPlayer("annoyed cat", groupName, false)
+	StartGame(groupName, "host cat")
+	AddPrompt("annoyed cat", groupName, "tuna", "stinky", "yummy")
+	AddPrompt("host cat", groupName, "big", "handsome", "can")
+	gameStatus, err := SubmitDrawing("annoyed cat", groupName, "mock data")
+	assert.Nil(t, err)
+	assert.NotNil(t, gameStatus)
+}
+
+func TestSubmitDrawing_Fails_PlayerMissing(t *testing.T) {
+	//set up a group, add players, add a prompt
+	groupName := randomGroupName()
+	CreateGroup(groupName)
+	AddPlayer("host cat", groupName, true)
+	AddPlayer("annoyed cat", groupName, false)
+	StartGame(groupName, "host cat")
+	AddPrompt("annoyed cat", groupName, "tuna", "stinky", "yummy")
+	AddPrompt("host cat", groupName, "big", "handsome", "can")
+	gameStatus, err := SubmitDrawing("ninja cat", groupName, "mock data")
+	assert.Nil(t, gameStatus)
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
- Adds a field `hasCompletedAction` to the current player, this way different screens (e.g. the drawing one) can know if they should ask the player to enter something or show a waiting screen.
- Adds a field `hasPendingActions` to the player array in the response, this way different states can mark which players the game is waiting for.
- Modifies the drawing state to populate these new fields
- Modifies the drawing UI to either show the canvas or show the status for the rest of the players based on whether or not the current player has completed their action

@apairofcleats @mick-warehime 