### PR TITLE
Make groups case insensitive:

### DIFF
--- a/client/src/components/GroupSelectionScreen/GroupSelectionScreen.jsx
+++ b/client/src/components/GroupSelectionScreen/GroupSelectionScreen.jsx
@@ -48,7 +48,7 @@ class GroupSelectionScreen extends React.Component {
   }
 
   onGroupNameChange(event) {
-    this.setState({ groupName: event.target.value });
+    this.setState({ groupName: event.target.value.toLocaleLowerCase() });
   }
 
   render() {


### PR DESCRIPTION
This way it'll be easier to type in the correct group.